### PR TITLE
Add CI workflow and improve error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust (stable) with rustfmt
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-
 // New module to encapsulate the reading, parsing, and updating of package-lock.json, as well as the URL update functionality
 pub mod package_lock_lib {
     use regex::Regex;
@@ -47,9 +46,13 @@ pub mod package_lock_lib {
 
         // Determine new URL based on argument
         let new_url = if arg == "--local" {
-            config["local"].as_str().ok_or("Local URL not found in pkg.config.json")?
+            config["local"]
+                .as_str()
+                .ok_or("Local URL not found in pkg.config.json")?
         } else if arg == "--remote" {
-            config["remote"].as_str().ok_or("Remote URL not found in pkg.config.json")?
+            config["remote"]
+                .as_str()
+                .ok_or("Remote URL not found in pkg.config.json")?
         } else {
             return Err("Invalid argument. Use --local or --remote.".into());
         };
@@ -140,4 +143,4 @@ pub mod package_lock_lib {
             fs::remove_file("package-lock.json").unwrap();
         }
     }
-} 
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::process;
 
 // Import the update_urls_in_package_lock function from the package_lock_lib module
 use pkglock_lib::package_lock_lib::update_urls_in_package_lock;
@@ -6,8 +7,8 @@ use pkglock_lib::package_lock_lib::update_urls_in_package_lock;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 || (args[1] != "--local" && args[1] != "--remote") {
-        println!("Usage: program --local | --remote");
-        return Ok(());
+        eprintln!("Usage: pkglock --local|--remote");
+        process::exit(2);
     }
 
     // Delegate processing to the lib module function

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,6 @@
+use pkglock_lib::package_lock_lib::{update_urls, update_urls_in_package_lock};
 use serde_json::Value;
 use std::fs;
-use pkglock_lib::package_lock_lib::{update_urls, update_urls_in_package_lock};
 
 #[test]
 fn test_file_operations() {
@@ -71,4 +71,4 @@ fn test_update_urls_in_package_lock() {
     // Clean up temporary files
     fs::remove_file("pkg.config.json").unwrap();
     fs::remove_file("package-lock.json").unwrap();
-} 
+}


### PR DESCRIPTION
After fetching the latest origin/main, the only differences on chore/ci-fmt-and-cli-exitcode are the 4 files you expected:
.github/workflows/ci.yml (adds cargo fmt -- --check CI job)
src/main.rs (prints Usage: pkglock --local|--remote and exits non‑zero on invalid args)
src/lib.rs (rustfmt)
tests/integration_test.rs (rustfmt)
Your earlier PR (docs + Cargo.toml metadata) is already merged into origin/main, so it won’t be part of this PR.